### PR TITLE
Add Message Children

### DIFF
--- a/src/Swiftmailer/Transport/SendGridTransport.php
+++ b/src/Swiftmailer/Transport/SendGridTransport.php
@@ -132,6 +132,11 @@ class SendGridTransport implements Swift_Transport
         $email->setSubject($message->getSubject());
         $email->addContent($message->getContentType(), $message->getBody());
 
+        $children = $message->getChildren();
+        foreach ($children as $child) {
+            $email->addContent($child->getContentType(), $child->getBody());
+        }
+
         $response = $this->client->send($email);
 
         if (202 === $response->statusCode()) {


### PR DESCRIPTION
When trying to send a multi-part message, the text/plain part was coming through, but the text/html part was not.  I tracked it down to this method.